### PR TITLE
Update loadBedTrackFromFile function to ignore shiny query strings #88 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: igvShiny
 Title: igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an interactive
     tool for visualization and exploration integrated genomic data)
-Version: 1.0.4
+Version: 1.0.5
 Date: 2024-08-25
 Authors@R: c(
     person("Paul","Shannon", role = c("aut"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## igvShiny 1.0.5 - 2024-08-29
+* fix issue with loading bed files when app is run with query strings
+
 ## igvShiny 1.0.4 - 2024-08-25
 * switch from Rcurl::url.exists to httr::http_error (Windows compatibility)
 

--- a/inst/htmlwidgets/igvShiny.js
+++ b/inst/htmlwidgets/igvShiny.js
@@ -456,7 +456,7 @@ Shiny.addCustomMessageHandler("loadBedTrackFromFile",
       var igvBrowser = document.getElementById(elementID).igvBrowser;
       var trackName = message.trackName;
       var bedFile = message.bedFilepath;
-      var dataURL = window.location.href + bedFile;
+      var dataURL = window.location.href.split('?')[0] + bedFile; // If a query string is present the url before that is used
       igvshiny_log("dataURL: " + dataURL);
 
       var color = message.color;


### PR DESCRIPTION
Fix for issue #88 

Updated the dataURL code to remove query strings and use the base url:

```
var dataURL = window.location.href.split('?')[0] + bedFile;
```