### PR TITLE
feat: stream local BAM in showcase demo and update local data demo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## igvShiny 1.9.44
 * Add HTTP Range Request streaming for local BAM and CRAM tracks (#174)
 * Add serveLocalFile and loadBamTrackFromLocalFile for zero-RAM local alignment streaming (#174)
+* Add BAM local file stream to the flagship demo and update local-data demo
 
 ## igvShiny 1.9.43
 * Remove the track files a session wrote when that session ends (#152)

--- a/demo/posit-connect/README.md
+++ b/demo/posit-connect/README.md
@@ -9,16 +9,17 @@ Two lines: it runs `inst/showcase/igvShinyDemo.R` out of the installed package.
 There is no second copy of the app to keep in sync — this used to be a
 hand-maintained fork, and it drifted from the original on every new loader.
 
-The flagship demo loads no file server-side: no `*FromLocalData` loader, hence
-no `GenomicAlignments` / `Rsamtools` / `VariantAnnotation` — the heavy
-C-compiled Bioconductor packages — in this deploy. Those loaders are demoed by
-`inst/demos/local-data.R`, which is not what gets published here. Alignment
-tracks are still on show: **BAM (URL)** and **CRAM (URL)** stream in the
-browser, with zero server-side dependency.
+The flagship demo avoids `*FromLocalData` loaders that require `GenomicAlignments` /
+`Rsamtools` / `VariantAnnotation` — the heavy C-compiled Bioconductor packages — in this deploy.
+Those in-memory loaders are demoed by `inst/demos/local-data.R`. For local alignments, the demo
+features **BAM (Local File Stream)** streaming `inst/extdata/tumor.bam` directly from disk via
+HTTP 206 Range Requests (`loadBamTrackFromLocalFile()`, zero R memory overhead, no Bioconductor C deps),
+alongside remote **BAM (URL)** and **CRAM (URL)** tracks.
 
 Server-side runtime footprint is tiny: a 74 KB `gwas.RData` loaded at startup
-(from the installed package via `system.file()`) plus small in-memory
-`data.frame`s built on click. All heavy rendering happens client-side in igv.js.
+(from the installed package via `system.file()`), small in-memory `data.frame`s
+built on click, and zero-RAM disk-streaming of `tumor.bam`. All heavy rendering
+happens client-side in igv.js.
 
 ## Deploy
 
@@ -106,4 +107,4 @@ merges, and the next republish fails with nothing to point at.
 **BAM from URL**, **CRAM from URL**, and **BedGraph from URL** stream from
 `1000genomes.s3.amazonaws.com` / `encodeproject.org`. When those hosts are slow
 or return 5xx the tracks look broken even though the app is fine. The inline /
-local-data buttons (BED, BedGraph, bed9, GWAS) always work offline.
+local-data buttons (BED, BedGraph, bed9, GWAS, BAM Local File Stream) always work offline.

--- a/demo/posit-connect/app.R
+++ b/demo/posit-connect/app.R
@@ -8,8 +8,8 @@
 #
 # The demo file is inside the installed package, so manifest.json's pinned
 # igvShiny commit decides which version of the app is served - see README.md.
-# The flagship deliberately avoids the *FromLocalData loaders, which is what
-# keeps Rsamtools / GenomicAlignments out of this deploy.
+# The flagship avoids in-memory *FromLocalData loaders to keep Rsamtools /
+# GenomicAlignments out of this deploy; local BAM streaming uses loadBamTrackFromLocalFile().
 
 library(igvShiny)
 

--- a/demo/posit-connect/manifest.json
+++ b/demo/posit-connect/manifest.json
@@ -1142,7 +1142,7 @@
       "description": {
         "Package": "igvShiny",
         "Title": "igvShiny: a wrapper of Integrative Genomics Viewer (IGV - an\ninteractive tool for visualization and exploration integrated\ngenomic data)",
-        "Version": "1.9.42",
+        "Version": "1.9.44",
         "Date": "2026-07-17",
         "Authors@R": "c(\n    person(\"Paul\",\"Shannon\", role = c(\"aut\"), \n    email = \"paul.thurmond.shannon@gmail.com\"),\n    person(\"Arkadiusz\", \"Gladki\", role=c(\"aut\", \"cre\"), \n    email=\"gladki.arkadiusz@gmail.com\", comment = c(ORCID = \"0000-0002-7059-6378\")),\n    person(\"Karolina\",\"Scigocka\", role = c(\"aut\"),\n    email = \"scigocka.karolina@gmail.com\"),\n    person(\"Carolina\", \"Heimann\", role = c(\"ctb\"),\n    email = \"carolina.heimann@gmail.com\"),\n    person(\"Steffen\", \"Klasberg\", role = c(\"ctb\"),\n    email = \"klasberg@dkms-lab.de\"),\n    person(\"Vincent\", \"Carey\", role = c(\"ctb\"),\n    email = \"stvjc@channing.harvard.edu\"),\n    person(\"Parv\", \"Sachdeva\", role = c(\"ctb\"),\n    email = \"parv.sachdeva@sonomabio.com\"),\n    person(\"Mateusz\", \"Gladki\", role = c(\"ctb\"),\n    email = \"gladkiimateusz@gmail.com\")\n    )",
         "Description": "This package is a wrapper of Integrative Genomics Viewer (IGV).\n    It comprises an htmlwidget version of IGV. It can be used as a module \n    in Shiny apps. ",
@@ -1162,11 +1162,11 @@
         "RemoteRepo": "igvShiny",
         "RemoteUsername": "gladkia",
         "RemoteRef": "master",
-        "RemoteSha": "3410ff5d9657df13e01382cfd03cc9b608fda81b",
+        "RemoteSha": "81ec6e2f8cee96fb2fc4c5f594b323f5b8c44452",
         "GithubRepo": "igvShiny",
         "GithubUsername": "gladkia",
         "GithubRef": "master",
-        "GithubSHA1": "3410ff5d9657df13e01382cfd03cc9b608fda81b",
+        "GithubSHA1": "81ec6e2f8cee96fb2fc4c5f594b323f5b8c44452",
         "NeedsCompilation": "no",
         "Packaged": "2026-07-23 05:47:57 UTC; arek",
         "Author": "Paul Shannon [aut],\n  Arkadiusz Gladki [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7059-6378>),\n  Karolina Scigocka [aut],\n  Carolina Heimann [ctb],\n  Steffen Klasberg [ctb],\n  Vincent Carey [ctb],\n  Parv Sachdeva [ctb],\n  Mateusz Gladki [ctb]",
@@ -2045,10 +2045,10 @@
   },
   "files": {
     "app.R": {
-      "checksum": "fa0916c4747b5823d4206c193caa75e7"
+      "checksum": "f75d70f1745dc38a929b079f3eaa5588"
     },
     "README.md": {
-      "checksum": "eb28e1bf91e2957d13775a8ca6efc931"
+      "checksum": "f3cb3dcb3b57aac1498e65d60d70271a"
     }
   },
   "users": null

--- a/inst/demos/local-data.R
+++ b/inst/demos/local-data.R
@@ -1,6 +1,14 @@
-# igvShiny — alignments and variants that are already in R: the *FromLocalData
-# loaders write a file into the tracks directory and have shiny serve it, so
-# unlike the URL loaders they need the parsing package on the server side.
+# igvShiny — alignments and variants: local files vs in-memory R objects.
+#
+# For local BAM files on disk, loadBamTrackFromLocalFile() streams alignments
+# directly via HTTP 206 Partial Content (range requests) with zero RAM overhead
+# and without requiring heavy compiled Bioconductor dependencies.
+#
+# For alignments and variants already loaded in R memory, loadBamTrackFromLocalData()
+# and loadVcfTrack() serialize the R objects and serve them from the session's tracks
+# directory. (Note: loadBamTrackFromLocalData also accepts a file path directly,
+# delegating to loadBamTrackFromLocalFile).
+#
 # Loaded on click, not at startup: a missing suggested package should grey out
 # one button rather than the whole app. Junctions are in junctions.R, GFF3 in
 # gff3.R.
@@ -22,7 +30,8 @@ ui <- page_sidebar(
   fillable = TRUE,
   sidebar = sidebar(
     width = 280,
-    actionButton("addLocalBamButton", "BAM (readGAlignments)", class = "w-100 mb-2"),
+    actionButton("addLocalBamStreamButton", "BAM (loadBamTrackFromLocalFile)", class = "w-100 mb-2"),
+    actionButton("addLocalBamButton", "BAM (readGAlignments in R)", class = "w-100 mb-2"),
     actionButton("addLocalVcfButton", "VCF (readVcf)", class = "w-100 mb-2"),
     actionButton("removeUserTracksButton", "Remove user tracks",
                  class = "btn-outline-danger w-100")
@@ -32,11 +41,18 @@ ui <- page_sidebar(
 )
 
 server <- function(input, output, session) {
+  observeEvent(input$addLocalBamStreamButton, {
+    showGenomicRegion(session, id = "igvShiny_0", "chr21:10,397,614-10,423,341")
+    bam <- system.file(package = "igvShiny", "extdata", "tumor.bam")
+    loadBamTrackFromLocalFile(session, id = "igvShiny_0", trackName = "tumor.bam (stream)",
+                              bamFile = bam)
+  })
+
   observeEvent(input$addLocalBamButton, {
     if (!needs("GenomicAlignments")) return()
     showGenomicRegion(session, id = "igvShiny_0", "chr21:10,397,614-10,423,341")
     bam <- system.file(package = "igvShiny", "extdata", "tumor.bam")
-    loadBamTrackFromLocalData(session, id = "igvShiny_0", trackName = "tumor.bam",
+    loadBamTrackFromLocalData(session, id = "igvShiny_0", trackName = "tumor.bam (in-memory)",
                               data = GenomicAlignments::readGAlignments(bam))
   })
 

--- a/inst/showcase/igvShinyDemo.R
+++ b/inst/showcase/igvShinyDemo.R
@@ -5,11 +5,13 @@
 # tests/testthat/test-shinyApp.R drives, so the input ids are part of the
 # contract: renaming one breaks a test and the live demo at the same time.
 #
-# Deliberately no *FromLocalData loader here: those pull Rsamtools /
-# GenomicAlignments / VariantAnnotation, heavy C-compiled Bioconductor deps
-# that would have to be installed on the cloud host just to serve a demo
-# button. They live in local-data.R instead. Everything below is either built
-# from a data.frame or fetched client-side by igv.js from a URL.
+# In-memory *FromLocalData loaders (GenomicAlignments / VariantAnnotation) live
+# in local-data.R to avoid heavy compiled Bioconductor dependencies on the cloud
+# host. For local BAM files, loadBamTrackFromLocalFile() streams alignments
+# directly from disk via HTTP 206 Partial Content (range requests) with zero
+# R RAM overhead and no compiled Bioconductor dependencies. Everything below is
+# either built from a data.frame, streamed locally via range requests, or fetched
+# client-side by igv.js from a URL.
 
 library(shiny)
 library(bslib)
@@ -86,7 +88,8 @@ ui <- page_sidebar(
         demoButton("addBedGraphWithAltColorTrackButton", "BedGraph (AltColor)", "palette"),
         demoButton("addBed9TrackButton", "bed9", "grip-lines"),
         demoButton("addGwasTrackButton", "GWAS", "chart-column"),
-        demoButton("addGwasCustomTrackButton", "GWAS (columns + colors)", "palette")
+        demoButton("addGwasCustomTrackButton", "GWAS (columns + colors)", "palette"),
+        demoButton("addBamFileStreamButton", "BAM (Local File Stream)", "dna")
       ),
 
       accordion_panel(
@@ -204,6 +207,13 @@ server <- function(input, output, session) {
                        trackHeight = 200,
                        chromosomeColorMap = list("19" = "purple", "*" = "gray"))
     display(track, session, id = "igvShiny_0", deleteTracksOfSameName = FALSE)
+  })
+
+  observeEvent(input$addBamFileStreamButton, {
+    showGenomicRegion(session, id = "igvShiny_0", "chr21:10,397,614-10,423,341")
+    bamFile <- system.file(package = "igvShiny", "extdata", "tumor.bam")
+    loadBamTrackFromLocalFile(session, id = "igvShiny_0", trackName = "tumor.bam",
+                              bamFile = bamFile)
   })
 
   observeEvent(input$addBamViaHttpButton, {

--- a/tests/testthat/test-shinyApp.R
+++ b/tests/testthat/test-shinyApp.R
@@ -48,6 +48,7 @@ test_that("igvShinyDemo loads tracks correctly", {
     # the remote ENCODE bigWig has a test of its own below, see the note there
     .click_and_check(app, "addBamViaHttpButton", 'title="NA19240.bam"')
     .click_and_check(app, "addCramViaHttpButton", 'title="CRAM"')
+    .click_and_check(app, "addBamFileStreamButton", 'title="tumor.bam"')
 
     app$stop()
 })


### PR DESCRIPTION
Related: #176, #174

## What changed

- Added `BAM (Local File Stream)` button to `inst/showcase/igvShinyDemo.R` demonstrating native HTTP 206 Partial Content range request streaming of `inst/extdata/tumor.bam` without requiring compiled Bioconductor C dependencies (`GenomicAlignments`, `Rsamtools`).
- Refactored `inst/demos/local-data.R` to add `addLocalBamStreamButton` for direct file streaming via `loadBamTrackFromLocalFile()` alongside in-memory R object demo (`loadBamTrackFromLocalData()`).
- Updated integration tests in `tests/testthat/test-shinyApp.R` to click `addBamFileStreamButton` and assert `title="tumor.bam"`.
- Updated `demo/posit-connect/README.md` and `demo/posit-connect/app.R`, re-pinned `manifest.json` and verified with `bump-pin.sh --check`.
- Added entry to `NEWS.md`.

## How it was verified

- [x] `testthat::test_local()` passes locally (365 passed, 0 failed, 1 skipped) via `/local-test-check`
- [ ] `roxygen2::roxygenise()` re-run if anything in `R/` changed (no changes in `R/`)
- [x] `NEWS.md` entry added (imperative verb, ≤120 chars, no trailing full stop)
- [x] `./demo/posit-connect/bump-pin.sh --check` verifies manifest consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “BAM (Local File Stream)” option to the demo, allowing bundled BAM data to be streamed directly from disk.
  - Added a separate local-data option for comparing streamed BAM data with the existing in-memory loading method.

- **Documentation**
  - Updated demo documentation to describe BAM file streaming, offline availability, and runtime benefits.
  - Added a changelog entry for the new demo capability.

- **Tests**
  - Extended demo coverage to verify that the streamed BAM track loads and displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->